### PR TITLE
お気に入り機能実装

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -42,7 +42,7 @@ body {
 }
 
 .btn:focus,
-.btn:active{
+.btn:active {
   box-shadow: none !important;
   background-color: #ff907c;
   border: solid 2px #ff907c;
@@ -51,6 +51,8 @@ body {
 .bg-white-btn {
   background-color: white;
   color: #ff907c;
+  border: solid 2px #ff907c;
+  border-radius: 5px;
 }
 
 .object-fit-cover {
@@ -69,6 +71,10 @@ body {
   @media (max-width: 1024px) {
     font-size: 10px;
   }
+}
+
+.text-pink {
+  color: #ff907c;
 }
 
 /* header */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -116,36 +116,9 @@ footer {
   display: block;
   width: 40%;
   margin: 0 auto;
-}
-
-.popular-recipes-area {
-  width: 80%;
-  margin: 50px auto 0;
-}
-
-.popular-recipes-area h2 {
-  width: 100%;
-  border-bottom: 2px solid orange;
-  padding-bottom: 15px;
-  margin-bottom: 40px;
-}
-
-.popular-recipes {
-  width: 100%;
-  display: flex;
-  gap: 12%;
-  justify-content: space-between;
-  padding: 0 30px;
-}
-
-.popular-recipe p {
-  text-align: center;
-}
-
-.recipe-img {
-  width: 100%;
-  border-radius: 8px;
-  margin-bottom: 20px;
+  @media (max-width: 767px) {
+    width: 55%;
+  }
 }
 
 .custom-arrow-icon {
@@ -161,31 +134,6 @@ footer {
   border-color: black;
 }
 
-@media (max-width: 767px) {
-  .first-view-logo-img {
-    width: 55%;
-  }
-
-  .popular-recipes-area {
-    margin: 35px auto 0;
-  }
-
-  .popular-recipes-area h2 {
-    padding-bottom: 10px;
-    margin-bottom: 27px;
-  }
-
-  .popular-recipes {
-    flex-direction: column;
-    gap: 8px;
-    padding: 0;
-  }
-
-  .popular-recipe {
-    width: 75%;
-    margin: 0 auto;
-  }
-}
 
 /* ユーザー認証 */
 .min-vh-80 {

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,28 @@
+class FavoritesController < ApplicationController
+  before_action :set_recipe
+  before_action :authenticate_user!
+
+  def create
+    favorite = @recipe.favorites.find_or_create_by(user_id: current_user.id)
+    favorite.save
+    respond_to do |format|
+      format.html { redirect_to recipe_path(@recipe) }
+      format.js
+    end
+  end
+
+  def destroy
+    favorite = @recipe.favorites.find_by(user_id: current_user.id)
+    favorite.destroy
+    respond_to do |format|
+      format.html { redirect_to recipe_path(@recipe) }
+      format.js
+    end
+  end
+
+  private
+
+  def set_recipe
+    @recipe = Recipe.find(params[:recipe_id])
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,5 +9,6 @@ class HomeController < ApplicationController
         recipes: category.recipes.recent.limit(TOP_PAGE_RECIPE_COUNT),
       }
     end
+    @favorite_recipes = Recipe.more_favorites.limit(TOP_PAGE_RECIPE_COUNT)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,5 +1,5 @@
 class RecipesController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy, :favorites]
   before_action :set_recipe, only: [:show, :edit, :update, :destroy]
   before_action :authorize_user, only: [:edit, :update, :destroy]
   before_action :get_categoties, onlu: [:new, :edit]
@@ -39,6 +39,10 @@ class RecipesController < ApplicationController
   def destroy
     @recipe.destroy
     redirect_to profile_path(current_user.id)
+  end
+
+  def favorites
+    @favorite_recipes = current_user.favorite_recipes.includes(:user).order(created_at: :desc)
   end
 
   private

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :recipe
+
+  validates :user_id, uniqueness: { scope: :recipe_id }
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -4,6 +4,8 @@ class Recipe < ApplicationRecord
   has_many :ingredients, dependent: :destroy
   has_many :instructions, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorited_by, through: :favorites, source: :user
 
   accepts_nested_attributes_for :ingredients, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :instructions, allow_destroy: true, reject_if: :all_blank

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -13,6 +13,7 @@ class Recipe < ApplicationRecord
   mount_uploader :recipe_image, RecipeImageUploader
 
   scope :recent, -> { includes(:user).order(created_at: :desc) }
+  scope :more_favorites, -> { left_joins(:favorites).group(:id).order('COUNT(favorites.id) DESC') }
 
   validates :title, presence: true, length: { maximum: 30 }
   validates :work_name, presence: true, length: { maximum: 30 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,10 @@ class User < ApplicationRecord
 
   has_many :recipes, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_recipes, through: :favorites, source: :recipe
+
+  def favorite?(recipe)
+    favorite_recipes.include?(recipe)
+  end
 end

--- a/app/views/favorites/_btn.html.erb
+++ b/app/views/favorites/_btn.html.erb
@@ -1,0 +1,30 @@
+<% if current_user && current_user.favorite?(recipe) %>
+  <%= link_to recipe_favorite_path(recipe),
+              method: :delete, remote: true,
+              data: { turbolinks: false },
+              class: "btn bg-white-btn d-flex align-items-center justify-content-center favorite-btn" do %>
+    <i class="bi bi-heart-fill fs-5 me-1" aria-hidden="true"></i>
+    <span class="text-dark">お気に入り</span>
+  <% end %>
+<% elsif current_user %>
+  <%= link_to recipe_favorite_path(recipe),
+              method: :post, remote: true,
+              data: { turbolinks: false },
+              class: "btn bg-white-btn d-flex align-items-center justify-content-center favorite-btn" do %>
+    <i class="bi bi-heart fs-5 me-1" aria-hidden="true"></i>
+    <span class="text-dark">お気に入り</span>
+  <% end %>
+<% else %>
+  <div class="nav-item dropdown">
+    <%= link_to "#",
+      class: "bg-white-btn d-flex align-items-center justify-content-center nav-link px-2 py-1 favorite-btn",
+      role: "button",
+      data: { bs_toggle: "dropdown" } do %>
+        <i class="bi bi-heart fs-5 me-1 text-pink" aria-hidden="true"></i>
+        <span class="text-dark">お気に入り</span>
+    <% end %>
+    <ul class="dropdown-menu border-0 py-0">
+      <li><p class="text-danger mt-1">ログインしてください</li>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,0 +1,1 @@
+$("#favorite-buttons-<%= @recipe.id %>").html("<%= j(render 'favorites/btn', recipe: @recipe) %>");

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#favorite-buttons-<%= @recipe.id %>').html("<%= j(render "favorites/btn", recipe: @recipe) %>");

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,21 +8,28 @@
       <button class="btn me-2" type="submit">Search</button>
     </form>
     <div class="popular-recipes-area">
-      <h2>人気レシピ</h2>
-        <ul class="popular-recipes">
-          <li class="popular-recipe">
-            <%= image_tag("logo_pic.png", class: "recipe-img") %>
-            <p>タイトル</p>
-          </li>
-          <li class="popular-recipe">
-            <%= image_tag("logo_pic.png", class: "recipe-img") %>
-            <p>タイトル</p>
-          </li>
-          <li class="popular-recipe">
-            <%= image_tag("logo_pic.png", class: "recipe-img") %>
-            <p>タイトル</p>
-          </li>
+      <h2 class="border-bottom border-warning mx-3 mb-3 pb-1">人気レシピ</h2>
+      <div class="px-lg-4 align-items-center">
+        <ul class="row gx-5 gy-2 px-lg-3 pe-md-4 px-0 d-md-flex justify-content-between ">
+          <% @favorite_recipes.each do |recipe| %>
+            <li class="flex-md-grow-1 col-10 col-md-4 mx-auto px-3 px-lg-4">
+              <%= link_to recipe_path(recipe.id), class: "text-decoration-none" do %>
+                <div class="mb-1">
+                  <%= image_tag recipe.recipe_image.thumb.url, class:"img-fluid rounded mb-2 mx-auto d-block", alt: "料理画像" %>
+                </div>
+                <p class="text-center fw-bold text-dark mb-0 custom-fs-16px"><%= recipe.title %></p>
+                <p class="text-dark text-center mb-0 custom-fs-14px"><%= recipe.work_name %></p>
+              <% end %>
+              <p class="text-muted text-center">
+                <%= link_to profile_path(recipe.user_id), class: "text-decoration-none" do %>
+                  <%= image_tag(recipe.user.avatar.smaller.url, alt: "アイコン画像", class: "img-fluid rounded-circle border border-muted") %>
+                  <span class="text-dark custom-fs-14px"><%= recipe.user.name %></span>
+                <% end %>
+              </p>
+            </li>
+          <% end %>
         </ul>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,10 +7,10 @@
       <input class="form-control form-control-lg mx-2 search-bar" type="search" placeholder="作品名、料理名" aria-label="Search">
       <button class="btn me-2" type="submit">Search</button>
     </form>
-    <div class="popular-recipes-area">
-      <h2 class="border-bottom border-warning mx-3 mb-3 pb-1">人気レシピ</h2>
+    <div class="popular-recipes-area col-10 offset-1">
+      <h2 class="border-bottom border-warning mx-md-3 mb-3 mt-4 pb-1">人気レシピ</h2>
       <div class="px-lg-4 align-items-center">
-        <ul class="row gx-5 gy-2 px-lg-3 pe-md-4 px-0 d-md-flex justify-content-between ">
+        <ul class="row gx-5 gy-2 px-lg-3 ps-0 d-md-flex justify-content-between ">
           <% @favorite_recipes.each do |recipe| %>
             <li class="flex-md-grow-1 col-10 col-md-4 mx-auto px-3 px-lg-4">
               <%= link_to recipe_path(recipe.id), class: "text-decoration-none" do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
                               data: { bs_toggle: "dropdown" },
                               aria: { expanded: "false" } %>
                   <ul class="dropdown-menu dropdown-menu-end text-center">
-                    <li><%= link_to "お気に入りレシピ", "#", class: "dropdown-item" %></li>
+                    <li><%= link_to "お気に入りレシピ", favorites_recipes_path(user_id: current_user.id), class: "dropdown-item" %></li>
                     <li><%= link_to "アカウント情報", profile_path(current_user.id), class: "dropdown-item" %></li>
                     <li><hr class="dropdown-divider"></li>
                     <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "dropdown-item" %></li>

--- a/app/views/recipes/favorites.html.erb
+++ b/app/views/recipes/favorites.html.erb
@@ -1,6 +1,6 @@
-<section class="bg-light py-lg-5 min-vh-80">
+<section class="bg-light py-lg-5 py-4 min-vh-80">
   <div class="container col-lg-8">
-      <h3 class="text-center border-bottom border-warning mb-3 pb-1">お気に入りレシピ一覧</h3>
+    <h3 class="text-center border-bottom border-warning mb-3 pb-1">お気に入りレシピ一覧</h3>
     <% if @favorite_recipes.any? %>
           <ul class="row gx-4 gy-2 ps-5 pe-5">
             <% @favorite_recipes.each do |recipe| %>

--- a/app/views/recipes/favorites.html.erb
+++ b/app/views/recipes/favorites.html.erb
@@ -1,0 +1,31 @@
+<section class="bg-light py-lg-5 min-vh-80">
+  <div class="container col-lg-8">
+      <h3 class="text-center border-bottom border-warning mb-3 pb-1">お気に入りレシピ一覧</h3>
+    <% if @favorite_recipes.any? %>
+          <ul class="row gx-4 gy-2 ps-5 pe-5">
+            <% @favorite_recipes.each do |recipe| %>
+              <li class="col-6 col-md-4">
+                <%= link_to recipe_path(recipe.id), class: "text-decoration-none recipe-link" do %>
+                  <div class="mb-1">
+                    <%= image_tag recipe.recipe_image.thumb.url, class:"img-fluid rounded mb-2 mx-auto d-block", alt: "料理画像" %>
+                  </div>
+                  <p class="text-center fw-bold text-dark mb-0 custom-fs-16px"><%= recipe.title %></p>
+                  <p class="text-dark text-center mb-0 custom-fs-14px"><%= recipe.work_name %></p>
+                <% end %>
+                <p class="text-muted text-center">
+                  <%= link_to profile_path(recipe.user_id), class: "text-decoration-none user-link" do %>
+                    <%= image_tag(recipe.user.avatar.smaller.url, alt: "アイコン画像", class: "img-fluid rounded-circle border border-muted") %>
+                    <span class="text-dark custom-fs-14px"><%= recipe.user.name %></span>
+                  <% end %>
+                </p>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+    <% else %>
+      <div class="alert alert-info" role="alert">
+        お気に入りのレシピはまだありません。
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -14,7 +14,7 @@
             <h4 class="mb-3 pb-2 px-2 border-bottom"><strong>作品名(<%= @recipe.category.name %>):</strong> <%= @recipe.work_name %></h4>
             <div class="d-flex mb-3 ps-1">
               <%= link_to profile_path(@recipe.user_id), class: "text-decoration-none d-flex" do %>
-                <%= image_tag @user.avatar.url(:small), class: "rounded-circle me-2", alt: "アバター画像" %>
+                <%= image_tag @recipe.user.avatar.url(:small), class: "rounded-circle me-2", alt: "アバター画像" %>
                 <p class="d-flex align-items-center mb-0 text-muted"><%= @recipe.user.name %></p>
               <% end %>
             </div>
@@ -23,9 +23,11 @@
               <h4>ポイント・コツ</h4>
               <p class="mb-2 border-start border-2 ps-3 py-1 text-muted"><%= @recipe.tip %></p>
             </div>
-            <%= link_to "お気に入り登録", "#", class: "btn me-3 bg-white-btn" %>
+            <div id="favorite-buttons-<%= @recipe.id %>" class="d-inline-block">
+              <%= render "favorites/btn", recipe: @recipe %>
+            </div>
             <% if @is_author %>
-              <%= link_to "編集する", edit_recipe_path(@recipe), class: "text-decoration-none" %>
+              <%= link_to "編集する", edit_recipe_path(@recipe), class: "text-decoration-none d-inline-block" %>
             <% end %>
           </div>
         </div>

--- a/config/initializers/carrirewave.rb
+++ b/config/initializers/carrirewave.rb
@@ -15,6 +15,6 @@ CarrierWave.configure do |config|
     config.root = Rails.root.join('public')
   else
     config.storage :file
-    config.enable_processing = false
+    config.enable_processing = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'favorites/create'
+  get 'favorites/destroy'
   root 'home#index'
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
@@ -8,6 +10,8 @@ Rails.application.routes.draw do
   resources :profiles, only: [:show, :edit, :update]
   resources :recipes, except: [:index] do
     resources :comments, only: [:create, :edit, :update, :destroy]
+    resource :favorite, only: [:create, :destroy]
+    get :favorites, on: :collection
   end
   resources :categories, only: [:show]
 end

--- a/db/migrate/20250204133553_create_favorites.rb
+++ b/db/migrate/20250204133553_create_favorites.rb
@@ -1,0 +1,12 @@
+class CreateFavorites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :favorites, [:user_id, :recipe_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_03_083631) do
+ActiveRecord::Schema.define(version: 2025_02_04_133553) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -26,6 +26,16 @@ ActiveRecord::Schema.define(version: 2025_02_03_083631) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["recipe_id"], name: "index_comments_on_recipe_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "favorites", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["recipe_id"], name: "index_favorites_on_recipe_id"
+    t.index ["user_id", "recipe_id"], name: "index_favorites_on_user_id_and_recipe_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "ingredients", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -76,6 +86,8 @@ ActiveRecord::Schema.define(version: 2025_02_03_083631) do
 
   add_foreign_key "comments", "recipes"
   add_foreign_key "comments", "users"
+  add_foreign_key "favorites", "recipes"
+  add_foreign_key "favorites", "users"
   add_foreign_key "ingredients", "recipes"
   add_foreign_key "instructions", "recipes"
   add_foreign_key "recipes", "users"

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    association :user
+    association :recipe
+  end
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  let!(:favorite) { create(:favorite) }
+
+  describe "バリデーションのテスト" do
+    it { should validate_uniqueness_of(:user_id).scoped_to(:recipe_id) }
+  end
+
+  describe "アソシエーションのテスト" do
+    it { should belong_to(:user) }
+    it { should belong_to(:recipe) }
+  end
+end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -58,9 +58,15 @@ RSpec.describe Recipe, type: :model do
   describe 'スコープのテスト' do
     let!(:older_recipe) { create(:recipe, created_at: 1.day.ago) }
     let!(:newer_recipe) { create(:recipe, created_at: Time.zone.now) }
+    let(:user) { create(:user) }
+    let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: newer_recipe.id) }
 
     it 'recentスコープで新しい順に取得できること' do
       expect(Recipe.recent).to eq [newer_recipe, older_recipe]
+    end
+
+    it "more_favoritesで人気順に取得できること" do
+      expect(Recipe.more_favorites).to eq [newer_recipe, older_recipe]
     end
   end
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe Recipe, type: :model do
     it { should belong_to(:category) }
     it { should have_many(:ingredients).dependent(:destroy) }
     it { should have_many(:instructions).dependent(:destroy) }
+    it { should have_many(:favorites).dependent(:destroy) }
+    it { should have_many(:favorited_by).through(:favorites).source(:user) }
   end
 
   describe 'スコープのテスト' do

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -47,5 +47,26 @@ RSpec.describe User, type: :model do
 
   describe "アソシエーションのテスト" do
     it { should have_many(:recipes) }
+    it { should have_many(:favorites).dependent(:destroy) }
+    it { should have_many(:favorite_recipes).through(:favorites).source(:recipe) }
+  end
+
+  describe "#favorite?" do
+    let(:recipe) { create(:recipe) }
+    let(:user) { create(:user) }
+
+    context "お気に入りに追加されている場合" do
+      let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: recipe.id) }
+
+      it "true を返すこと" do
+        expect(user.favorite?(recipe)).to be true
+      end
+    end
+
+    context "お気に入りに追加されていない場合" do
+      it "false を返すこと" do
+        expect(user.favorite?(recipe)).to be false
+      end
+    end
   end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :request do
+  let(:user)   { create(:user) }
+  let(:recipe) { create(:recipe) }
+
+  before { sign_in user }
+
+  describe "POST /recipes/:recipe_id/favorite" do
+    it "お気に入りが新規作成されること" do
+      expect { post recipe_favorite_path(recipe) }.to change(Favorite, :count).by(1)
+      expect(response).to redirect_to(recipe_path(recipe))
+    end
+  end
+
+  describe "DELETE /recipes/:recipe_id/favorite" do
+    let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: recipe.id) }
+    it "お気に入りが削除されること" do
+      expect { delete recipe_favorite_path(recipe) }.to change(Favorite, :count).by(-1)
+      expect(response).to redirect_to(recipe_path(recipe))
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe "Home", type: :request do
     end
 
     it "カテゴリーに属するレシピが最新の3つのみ含まれていること" do
-      puts response.body
       expect(response.body).to include(category_recipes[1].title)
       expect(response.body).to include(category_recipes[2].title)
       expect(response.body).to include(category_recipes[3].title)

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -36,10 +36,11 @@ RSpec.describe "Home", type: :request do
       html = Nokogiri::HTML(response.body)
       popular_section = html.at_css('.popular-recipes-area')
       popular_text = popular_section.text
-      expect(response.body).to include(recipes[1].title)
-      expect(response.body).to include(recipes[2].title)
-      expect(response.body).to include(recipes[3].title)
-      expect(response.body).not_to include(recipes[0].title)
+
+      expect(popular_text).to include(recipes[1].title)
+      expect(popular_text).to include(recipes[2].title)
+      expect(popular_text).to include(recipes[3].title)
+      expect(popular_text).not_to include(recipes[0].title)
     end
 
     it "各カテゴリのレシピセクションが表示されていること" do

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe "Home", type: :request do
+  let!(:categories) do
+    create_list(:category, 2)
+  end
+  let!(:recipes) do
+    create_list(:recipe, 4).each_with_index do |recipe, index|
+      recipe.update(title: "test_recipe_#{index}")
+    end
+  end
+  let!(:category_recipes) do
+    create_list(:recipe, 4, category_id: categories[0].id).each_with_index do |recipe, index|
+      recipe.update(created_at: index.day.ago)
+    end
+  end
+
+  before do
+    allow(Category).to receive(:where).with(id: [1, 2, 3, 4]).and_return(categories)
+    recipes.each_with_index do |recipe, index|
+      create_list(:favorite, index, recipe: recipe)
+    end
+    get root_path
+  end
+
+  describe "Get /" do
+    it "レスポンスが正常であること" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "人気レシピセクションが含まれていること" do
+      expect(response.body).to include("人気レシピ")
+    end
+
+    it "人気レシピとして人気のも最も高い3つのみが表示されること" do
+      html = Nokogiri::HTML(response.body)
+      popular_section = html.at_css('.popular-recipes-area')
+      popular_text = popular_section.text
+      expect(response.body).to include(recipes[1].title)
+      expect(response.body).to include(recipes[2].title)
+      expect(response.body).to include(recipes[3].title)
+      expect(response.body).not_to include(recipes[0].title)
+    end
+
+    it "各カテゴリのレシピセクションが表示されていること" do
+      get root_path
+      categories.each do |category|
+        expect(response.body).to include(category.name)
+      end
+    end
+
+    it "カテゴリーに属するレシピが最新の3つのみ含まれていること" do
+      puts response.body
+      expect(response.body).to include(category_recipes[1].title)
+      expect(response.body).to include(category_recipes[2].title)
+      expect(response.body).to include(category_recipes[3].title)
+      expect(response.body).not_to include(recipes[0].title)
+    end
+  end
+end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe "Recipes", type: :request do
         )
         expect(response.body).not_to include(other_recipe.title)
       end
+
+      it "お気に入りボタンが含まれていること" do
+        expect(response.body).to include("お気に入り")
+      end
     end
   end
 
@@ -225,6 +229,38 @@ RSpec.describe "Recipes", type: :request do
           delete recipe_path(recipe)
           expect(response).to redirect_to(new_user_session_path)
         end
+      end
+    end
+  end
+
+  describe "お気に入りレシピページ" do
+    before { get favorites_recipes_path }
+    let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: other_user_recipe.id) }
+
+    it "レスポンスが正常であること" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "見出しのお気に入りレシピ一覧が含まれていること" do
+      expect(response.body).to include("お気に入りレシピ一覧")
+    end
+
+    context "お気に入りレシピがある場合" do
+      it "お気に入りレシピの情報が含まれていること" do
+        get favorites_recipes_path
+
+        expect(response.body).to include(
+          other_user_recipe.title,
+          other_user_recipe.work_name,
+          "src=\"#{other_user_recipe.recipe_image.thumb.url}\"",
+          "src=\"#{other_user.avatar.smaller.url}\"",
+        )
+      end
+    end
+
+    context "お気に入りのレシピがない場合" do
+      it "レシピ情報が含まれていないこと" do
+        expect(response.body).to include("お気に入りのレシピはまだありません。")
       end
     end
   end

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Recipes", type: :system do
+  let(:user) { create(:user) }
+  let(:recipe) { create(:recipe) }
+
+  describe "お気に入りボタン" do
+    before do
+      sign_in user
+      visit recipe_path(recipe.id)
+    end
+
+    it "お気に入り登録ボタンが表示されていること" do
+      expect(page).to have_link("お気に入り")
+    end
+
+    context "このレシピがお気に入りにされていない場合" do
+      it "お気に入りボタンを押すと、ハートがピンクになること", js: true do
+        find(".favorite-btn").click
+        expect(page).to have_css(".bi-heart-fill")
+      end
+    end
+
+    context "このレシピがお気に入りの場合" do
+      before do
+        create(:favorite, user: user, recipe: recipe)
+        visit recipe_path(recipe)
+        expect(page).to have_css(".bi-heart-fill")
+      end
+
+      it "お気に入りボタンを押すと、ハートが白になること", js: true do
+        find(".favorite-btn").click
+        expect(page).to have_css(".bi-heart")
+      end
+    end
+
+    context "未ログイン場合" do
+      it "お気に入りボタンを押すと、ログインしてくださいと出ること", js: true do
+        sign_out user
+        visit recipe_path(recipe.id)
+        find(".favorite-btn").click
+        expect(page).to have_content("ログインしてください")
+      end
+    end
+  end
+
+  describe "お気に入りレシピページ" do
+    let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: recipe.id) }
+    let!(:other_recipe) { create(:recipe, title: "test_recipe2") }
+    let!(:older_favorite) { create(:favorite, user_id: user.id, recipe_id: other_recipe.id, created_at: 1.day.ago) }
+
+    before do
+      sign_in user
+      visit favorites_recipes_path
+    end
+
+    it "お気に入り登録したレシピ情報が表示されていること" do
+      expect(page).to have_selector("img[src$='#{recipe.recipe_image.thumb.url}']")
+      expect(page).to have_link(recipe.title, href: recipe_path(recipe.id))
+      expect(page).to have_link(recipe.work_name, href: recipe_path(recipe.id))
+      expect(page).to have_link(recipe.user.name, href: profile_path(recipe.user.id))
+      expect(page).to have_css("a[href='#{profile_path(recipe.user.id)}'] img[src$='#{recipe.user.avatar.smaller.url}']")
+    end
+
+    it "レシピ情報押下でレシピページへ遷移すること" do
+      all('.recipe-link').first.click
+      expect(current_path).to eq recipe_path(other_recipe.id)
+    end
+
+    it "ユーザー情報押下でプロフィールページへ遷移すること" do
+      all('.user-link').first.click
+      expect(current_path).to eq profile_path(other_recipe.user.id)
+    end
+
+    it "お気に入りにした最新順から並んでいること" do
+      display_recipes = all(".recipe-link")
+
+      expect(display_recipes.first).to have_content(other_recipe.title)
+      expect(display_recipes.last).to have_content(recipe.title)
+    end
+  end
+end

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Recipes", type: :system do
+RSpec.describe "Favorites", type: :system do
   let(:user) { create(:user) }
   let(:recipe) { create(:recipe) }
 

--- a/spec/system/recipes_spec.rb
+++ b/spec/system/recipes_spec.rb
@@ -113,10 +113,6 @@ RSpec.describe "Recipes", type: :system do
       expect(current_path).to eq(edit_recipe_path(recipe))
     end
 
-    it "お気に入り登録ボタンが表示されていること" do
-      expect(page).to have_link("お気に入り登録")
-    end
-
     it "ユーザー名をクリックするとプロフィールページに遷移すること" do
       within(".recipe-area") do
         click_link user.name


### PR DESCRIPTION
実装内容

ユーザーがレシピをお気に入り登録できる機能を実装しました。  
お気に入りしたデータはお気に入りの一覧ページ(recipes/favorites)で表示されます。
トップページの人気レシピをお気に入りの多い順に３つ表示されます。


1. Favoriteモデルを新規作成
2.  Userモデルとrecipeモデルとの多対多の関係を追加
3. FavoritesControllerを作成して以下のアクションを実装
  - create: お気に入り登録
  - destroy: お気に入り解除
4. レシピ詳細ページにお気に入りボタンを追加し、押下時に登録/解除できるようにした
5. お気に入りボタン押下で、ハートの色が変わるように実装
6. お気に入り一覧ページでお気に入りした項目の一覧を表示
7. トップページの人気レシピをスコープを使って取得し３つ表示
　