### PR TITLE
レシピ検索機能実装

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -45,6 +45,14 @@ class RecipesController < ApplicationController
     @favorite_recipes = current_user.favorite_recipes.includes(:user).order(created_at: :desc)
   end
 
+  def search
+    if params[:keyword].present?
+      @recipes = Recipe.search(params[:keyword])
+    else
+      @recipes = Recipe.none
+    end
+  end
+
   private
 
   def recipe_params

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -15,6 +15,17 @@ class Recipe < ApplicationRecord
   scope :recent, -> { includes(:user).order(created_at: :desc) }
   scope :more_favorites, -> { left_joins(:favorites).group(:id).order('COUNT(favorites.id) DESC') }
 
+  def self.search(search)
+    if search.present?
+      keywords = search.split(/[[:blank:]]+/)
+      conditions = keywords.map { "(title LIKE ? OR work_name LIKE ?)" }.join(" AND ")
+      values = keywords.flat_map { |keyword| ["%#{keyword}%", "%#{keyword}%"] }
+      where(conditions, *values)
+    else
+      none
+    end
+  end
+
   validates :title, presence: true, length: { maximum: 30 }
   validates :work_name, presence: true, length: { maximum: 30 }
   validates :recipe_image, presence: true

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,10 +3,10 @@
     <div class="bg-yellow py-5">
       <%= image_tag("first-view-logo.png", class: "d-block col-lg-5 col-md-7 col-9 mx-auto", alt: "ファーストビューロゴ") %>
     </div>
-    <form class="d-flex col-md-6 offset-md-3 mt-5" role="search">
-      <input class="form-control form-control-lg mx-2 search-bar" type="search" placeholder="作品名、料理名" aria-label="Search">
-      <button class="btn me-2" type="submit">Search</button>
-    </form>
+    <%= form_with url: search_recipes_path, method: :get, local: true, html: {class: "d-flex col-md-6 offset-md-3 mt-5", role: "search"} do |f| %>
+      <%= f.text_field :keyword, class: "form-control form-control-lg mx-2 search-bar shadow-sm rounded", placeholder: "作品名、料理名", "aria-label": "Search" %>
+      <%= f.submit "検索", class: "btn me-2 rounded" %>
+    <% end %>
     <div class="popular-recipes-area col-10 offset-1">
       <h2 class="border-bottom border-warning mx-md-3 mb-3 mt-4 pb-1">人気レシピ</h2>
       <div class="px-lg-4 align-items-center">

--- a/app/views/recipes/favorites.html.erb
+++ b/app/views/recipes/favorites.html.erb
@@ -23,7 +23,7 @@
           </ul>
         </div>
     <% else %>
-      <div class="alert alert-info" role="alert">
+      <div class="alert alert-info">
         お気に入りのレシピはまだありません。
       </div>
     <% end %>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -1,0 +1,33 @@
+<div class="container">
+  <%= form_with url: search_recipes_path, method: :get, local: true, html: {class: "d-flex col-md-6 offset-md-3 my-5", role: "search"} do |f| %>
+    <%= f.text_field :keyword, value: params[:keyword], class: "form-control form-control-lg mx-2 search-bar shadow-sm rounded", placeholder: "作品名、料理名", "aria-label": "Search" %>
+    <%= f.submit "検索", class: "btn me-2 rounded" %>
+  <% end %>
+
+  <div class="col-10 offset-1">
+    <h2 class="text-center border-bottom border-warning pb-2 mb-5 ">"<%= params[:keyword] %>"に関するレシピ</h2>
+    <% if @recipes.present? %>
+      <ul class="row gx-4 gy-2 ps-lg-5 pe-lg-5 px-1">
+        <% @recipes.each do |recipe| %>
+          <li class="col-6 col-md-4">
+            <%= link_to recipe_path(recipe.id), class: "text-decoration-none recipe-link" do %>
+              <%= image_tag recipe.recipe_image.thumb.url, class:"img-fluid rounded mb-2 mx-auto d-block object-fit-cover", alt: "料理画像" %>
+              <p class="text-center fw-bold text-dark mb-0 custom-fs-16px"><%= recipe.title %></p>
+              <p class="text-dark text-center mb-0 custom-fs-14px"><%= recipe.work_name %></p>
+            <% end %>
+            <p class="text-muted text-center">
+              <%= link_to profile_path(recipe.user.id), class: "text-decoration-none user-link" do %>
+                <%= image_tag(recipe.user.avatar.smaller.url, alt: "アイコン画像", class: "img-fluid rounded-circle border border-muted") %>
+                <span class="text-dark custom-fs-14px"><%= recipe.user.name %></span>
+              <% end %>
+            </p>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="alert alert-info">
+        <span>検索結果が見つかりませんでした</span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :destroy]
     resource :favorite, only: [:create, :destroy]
     get :favorites, on: :collection
+    get :search, on: :collection
   end
   resources :categories, only: [:show]
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -70,4 +70,33 @@ RSpec.describe Recipe, type: :model do
       expect(Recipe.more_favorites).to eq [newer_recipe, older_recipe]
     end
   end
+
+  describe "関数.searchのテスト" do
+    let!(:recipe1) { create(:recipe, title: "レシピ1", work_name: "ab") }
+    let!(:recipe2) { create(:recipe, title: "レシピ2", work_name: "ac") }
+    let!(:recipe3) { create(:recipe, title: "テスト3", work_name: "bc") }
+    let!(:recipe4) { create(:recipe, title: "レシピ4", work_name: "cd") }
+
+    context "検索キーワードが入力されたとき" do
+      it "全てのキーワードにマッチするレシピが取得できること" do
+        results = Recipe.search("レシピ a")
+        expect(results).to include(recipe1)
+        expect(results).to include(recipe2)
+        expect(results).not_to include(recipe3)
+        expect(results).not_to include(recipe4)
+      end
+
+      it "キーワードにマッチするレシピがない場合、何も取得できないこと" do
+        results = Recipe.search("nonexistent_keyword")
+        expect(results).to be_empty
+      end
+    end
+
+    context "検索キーワードが空欄の時" do
+      it "noneを返すこと" do
+        results = Recipe.search("")
+        expect(results).to be_empty
+      end
+    end
+  end
 end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -293,7 +293,5 @@ RSpec.describe "Recipes", type: :request do
         end
       end
     end
-
-
   end
 end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -234,34 +234,66 @@ RSpec.describe "Recipes", type: :request do
   end
 
   describe "お気に入りレシピページ" do
-    before { get favorites_recipes_path }
-    let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: other_user_recipe.id) }
+    describe "GET /recipes/favorites" do
+      before { get favorites_recipes_path }
+      let!(:favorite) { create(:favorite, user_id: user.id, recipe_id: other_user_recipe.id) }
 
-    it "レスポンスが正常であること" do
-      expect(response).to have_http_status(200)
+      it "レスポンスが正常であること" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "見出しのお気に入りレシピ一覧が含まれていること" do
+        expect(response.body).to include("お気に入りレシピ一覧")
+      end
+
+      context "お気に入りレシピがある場合" do
+        it "お気に入りレシピの情報が含まれていること" do
+          get favorites_recipes_path
+
+          expect(response.body).to include(
+            other_user_recipe.title,
+            other_user_recipe.work_name,
+            "src=\"#{other_user_recipe.recipe_image.thumb.url}\"",
+            "src=\"#{other_user.avatar.smaller.url}\"",
+          )
+        end
+      end
+
+      context "お気に入りのレシピがない場合" do
+        it "レシピ情報が含まれていないこと" do
+          expect(response.body).to include("お気に入りのレシピはまだありません。")
+        end
+      end
     end
+  end
 
-    it "見出しのお気に入りレシピ一覧が含まれていること" do
-      expect(response.body).to include("お気に入りレシピ一覧")
-    end
+  describe "検索機能" do
+    describe "GET /recipes/search" do
+      let!(:recipe1) { create(:recipe, title: "レシピ1", work_name: "ab") }
+      let!(:recipe2) { create(:recipe, title: "テスト2", work_name: "bc") }
 
-    context "お気に入りレシピがある場合" do
-      it "お気に入りレシピの情報が含まれていること" do
-        get favorites_recipes_path
+      context "検索キーワードが存在する場合" do
+        it "キーワードにマッチするデータを返すこと" do
+          get search_recipes_path, params: { keyword: "レシピ ab" }
 
-        expect(response.body).to include(
-          other_user_recipe.title,
-          other_user_recipe.work_name,
-          "src=\"#{other_user_recipe.recipe_image.thumb.url}\"",
-          "src=\"#{other_user.avatar.smaller.url}\"",
-        )
+          expect(response).to have_http_status(200)
+          expect(response.body).to include("レシピ1")
+          expect(response.body).to include("ab")
+          expect(response.body).not_to include("テスト2")
+        end
+      end
+
+      context "検索キーワードが空白の場合" do
+        it "何もデータを返さないこと" do
+          get search_recipes_path, params: { keyword: "" }
+
+          expect(response).to have_http_status(200)
+          expect(response.body).not_to include("レシピ1")
+          expect(response.body).not_to include("テスト2")
+        end
       end
     end
 
-    context "お気に入りのレシピがない場合" do
-      it "レシピ情報が含まれていないこと" do
-        expect(response.body).to include("お気に入りのレシピはまだありません。")
-      end
-    end
+
   end
 end

--- a/spec/system/recipes_spec.rb
+++ b/spec/system/recipes_spec.rb
@@ -224,4 +224,21 @@ RSpec.describe "Recipes", type: :system do
       expect(page).not_to have_content(recipe.title)
     end
   end
+
+  describe "レシピ検索" do
+    let!(:recipe1) { create(:recipe, title: "レシピ1", work_name: "ab") }
+    let!(:recipe2) { create(:recipe, title: "テスト2", work_name: "bc") }
+
+    it "キーワードにマッチするレシピ情報が表示されること" do
+      visit search_recipes_path
+      fill_in "keyword", with: "レシピ b"
+      click_button "検索"
+      expect(page).to have_content(recipe1.title)
+      expect(page).to have_content(recipe1.work_name)
+      expect(page).to have_selector("img[src$='#{recipe1.recipe_image.thumb.url}']")
+      expect(page).to have_content(recipe1.user.name)
+      expect(page).to have_selector("img[src$='#{recipe1.user.avatar.smaller.url}']")
+      expect(page).not_to have_content(recipe2.title)
+    end
+  end
 end


### PR DESCRIPTION
実装内容

ユーザーがトップページの検索フォームからキーワードを入力して、レシピのタイトルおよび作品名に対して部分一致で検索できる機能を実装しました。また複数のキーワードでも、全てのキーワードにマッチするレシピを検索できるようにしました。

1. recipeモデルに各キーワードに対し、titleとwork_nameから検索できるよう関数を追加
2. recipeコントローラーにsearchを追加し、.srearchメソッドを使い検索されたキーワードからレシピを取得できるよう実装
3. recipe/searchで検索結果一覧を表示