### PR TITLE
お問い合わせ機能の実装

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,36 @@
+class ContactsController < ApplicationController
+  def new
+    @contact = Contact.new
+  end
+
+  def confirm
+    @contact = Contact.new(contact_params)
+    if @contact.invalid?
+      flash[:alert] = @contact.errors.full_messages.join(", ")
+      render :new
+    end
+  end
+
+  def back
+    @contact = Contact.new(contact_params)
+    render :new
+  end
+
+  def create
+    @contact = Contact.new(contact_params)
+    if @contact.save
+      ContactMailer.send_mail(@contact).deliver_now
+      redirect_to root_path
+      flash[:notice] = "お問い合わせが完了しました。"
+    else
+      flash[:alert] = @contact.errors.full_messages.join(", ")
+      render :new
+    end
+  end
+
+  private
+
+  def contact_params
+    params.require(:contact).permit(:name, :email, :subject, :message)
+  end
+end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,0 +1,6 @@
+class ContactMailer < ApplicationMailer
+  def send_mail(contact)
+    @contact = contact
+    mail to:   ENV['GOOGLE_MAIL_ADDRESS'], subject: '【お問い合わせ】' + @contact.subject
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,6 @@
+class Contact < ApplicationRecord
+  validates :name, presence: true
+  validates :email, presence: true
+  validates :subject, presence: true
+  validates :message, presence: true, length: { maximum: 1000 }
+end

--- a/app/views/contact_mailer/send_mail.html.erb
+++ b/app/views/contact_mailer/send_mail.html.erb
@@ -1,0 +1,6 @@
+<%= @contact.name %> 様 から問い合わせがありました。<br>
+
+【メールアドレス】：<%= @contact.email %><br>
+【件名】：<%= @contact.subject %><br>
+【お問い合わせ内容】<br>
+<span style="white-space: pre-wrap;"><%= @contact.message %></span>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -2,7 +2,7 @@
 <div class="container p-5">
   <div class="row">
     <div class="col-md-10 offset-md-1">
-
+    <h2 class="text-center border-bottom pb-2 mb-3">お問い合わせ内容の確認</h2>
       <table class="table">
         <tbody>
           <tr>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -1,0 +1,49 @@
+<%= provide(:title, "お問い合わせ")%>
+<div class="container p-5">
+  <div class="row">
+    <div class="col-md-10 offset-md-1">
+
+      <table class="table">
+        <tbody>
+          <tr>
+            <td class="text-right" style="width: 30%;">お名前</td>
+            <td><%= @contact.name %></td>
+          </tr>
+          <tr>
+            <td class="text-right mt-3" style="width: 30%;">メールアドレス</td>
+            <td><%= @contact.email %></td>
+          </tr>
+          <tr>
+            <td class="text-right mt-3" style="width: 30%;">件名</td>
+            <td><%= @contact.subject %></td>
+          </tr>
+          <tr>
+            <td class="text-right mt-3">メッセージ</td>
+            <td style="white-space: pre-wrap;"><%= @contact.message %></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="d-flex justify-content-center">
+        <div class="d-flex align-items-center me-5">
+          <%= form_with model: @contact, url: back_contacts_path do |f| %>
+            <%= f.hidden_field :name %>
+            <%= f.hidden_field :email %>
+            <%= f.hidden_field :subject %>
+            <%= f.hidden_field :message %>
+            <div><%= f.submit '入力画面に戻る', class: "text-danger border-0 bg-white" %></div>
+          <% end %>
+        </div>
+        <div class="ms-5">
+          <%= form_with model: @contact do |f| %>
+            <%= f.hidden_field :name %>
+            <%= f.hidden_field :email %>
+            <%= f.hidden_field :subject %>
+            <%= f.hidden_field :message %>
+            <div><%= f.submit '送信', class: "btn" %></div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,0 +1,33 @@
+<%= provide(:title, "お問い合わせ")%>
+<div class="container my-5">
+  <div class="row">
+    <div class="col-md-8 offset-md-2">
+      <h2 class="text-center border-bottom pb-2 mb-3">お問い合わせ</h2>
+      <%= form_with model: @contact, url: confirm_contacts_path, local: true do |f| %>
+        <div class="form-group mb-4 mx-5">
+          <%= f.label :name, "お名前", class: "form-label" %>
+          <%= f.text_field :name, autofocus: true, class: "form-control" %>
+        </div>
+
+        <div class="form-group mb-4 mx-5">
+          <%= f.label :email, "メールアドレス", class: "form-label" %>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+
+        <div class="form-group mb-4 mx-5">
+          <%= f.label :subject, "件名", class: "form-label" %>
+          <%= f.text_area :subject, class: "form-control" %>
+        </div>
+
+        <div class="form-group mb-5 mx-5">
+          <%= f.label :message, "お問い合わせ内容(1000文字以内)", class: "form-label" %>
+          <%= f.text_area :message, size: '10x10', class: "form-control" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.submit '入力内容確認', class: "btn d-block mx-auto" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,9 +74,12 @@
 
   </body>
 
-  <footer class="bg-yellow">
+  <footer class="bg-yellow px-md-5 px-3 py-2">
     <% if current_user.try(:admin?) %>
       <%= link_to '管理者ログイン', rails_admin_path %>
     <% end %>
+    <div class="d-flex">
+     <p>お問い合わせは<span><%= link_to "こちら", new_contact_path, class:"text-decoration-none" %></span></p>
+    </div>
   </footer>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,6 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   host = 'localhost:3000'
   config.action_mailer.default_url_options = { host: host, protocol: 'http' }
   # メール送信失敗時のエラーを発生させる

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -9,7 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
       category: "カテゴリー"
       comment: "コメント"
       favorite: "お気に入り"
+      contact: "お問い合わせ"
     attributes:
       recipe:
         title: "レシピタイトル"
@@ -32,3 +33,8 @@ ja:
         content: "コメント内容"
         user: "ユーザー"
         recipe: "レシピ"
+      contact:
+        name: "名前"
+        email: "メールアドレス"
+        subject: "件名"
+        message: "お問い合わせ内容"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'contacts/new'
+  get 'contacts/create'
   root 'home#index'
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
@@ -16,5 +18,11 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   devise_scope :user do
     post 'users/guest_log_in', to: 'users/sessions#guest_log_in'
+  end
+  resources :contacts, only: [:new, :create] do
+    collection do
+        post 'confirm'
+        post 'back'
+    end
   end
 end

--- a/db/migrate/20250210052438_create_contacts.rb
+++ b/db/migrate/20250210052438_create_contacts.rb
@@ -1,0 +1,12 @@
+class CreateContacts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :contacts do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :subject, null: false
+      t.text :message, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_08_093243) do
+ActiveRecord::Schema.define(version: 2025_02_10_052438) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2025_02_08_093243) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["recipe_id"], name: "index_comments_on_recipe_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "contacts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "subject", null: false
+    t.text "message", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "favorites", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :contact do
+    name { "テストユーザー" }
+    email { "test@example.com" }
+    subject { "テスト件名" }
+    message { "これはテストメッセージです。" }
+  end
+end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe ContactMailer, type: :mailer do
+  describe "#send_mail" do
+    let(:contact) { build(:contact) }
+    let(:mail) { ContactMailer.send_mail(contact) }
+
+    it "正しい件名が設定されていること" do
+      expect(mail.subject).to eq("【お問い合わせ】#{contact.subject}")
+    end
+
+    it "正しい送信先が設定されていること" do
+      expect(mail.to).to eq([ENV['GOOGLE_MAIL_ADDRESS']])
+    end
+
+    it "メール本文に問い合わせ内容が含まれていること" do
+      expect(mail.body.encoded).to include(contact.name)
+      expect(mail.body.encoded).to include(contact.email)
+      expect(mail.body.encoded).to include(contact.subject)
+      expect(mail.body.encoded).to include(contact.message)
+    end
+  end
+end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ContactMailer, type: :mailer do
       expect(mail.to).to eq([ENV['GOOGLE_MAIL_ADDRESS']])
     end
 
-    it "メール本文に問い合わせ内容が含まれていること" do
+    it "メール本文に名前、メールアドレス、件名、問い合わせ内容が含まれていること" do
       expect(mail.body.encoded).to include(contact.name)
       expect(mail.body.encoded).to include(contact.email)
       expect(mail.body.encoded).to include(contact.subject)

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  describe "バリデーションのテスト" do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:email) }
+    it { should validate_presence_of(:subject) }
+    it { should validate_presence_of(:message) }
+    it { should validate_length_of(:message).is_at_most(1000) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require 'capybara/rspec'
+ENV['GOOGLE_MAIL_ADDRESS'] ||= 'test@example.com'
 
 Capybara.javascript_driver = :selenium_chromium_remote
 

--- a/spec/requests/contacts_spec.rb
+++ b/spec/requests/contacts_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe "Contacts", type: :request do
+  let(:valid_params) do
+    {
+      contact: {
+        name: "Test User",
+        email: "test@example.com",
+        subject: "Test Subject",
+        message: "This is a test message.",
+      },
+    }
+  end
+  let(:invalid_params) do
+    {
+      contact: {
+        name: "",
+        email: "",
+        subject: "",
+        message: "",
+      },
+    }
+  end
+
+  describe "GET /contacts/new" do
+    before { get new_contact_path }
+    it "レスポンスが正常であること" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "お問い合わせフォームが含まれていること" do
+      expect(response.body).to include("お問い合わせ")
+      expect(response.body).to include("名前")
+      expect(response.body).to include("メールアドレス")
+      expect(response.body).to include("件名")
+      expect(response.body).to include("お問い合わせ内容(1000文字以内)")
+    end
+  end
+
+  describe "POST /contacts/confirm" do
+    context "有効なパラメータの場合" do
+      it "確認画面が含まれ、入力内容が含まれていること" do
+        post confirm_contacts_path, params: valid_params
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("Test User")
+        expect(response.body).to include("test@example.com")
+        expect(response.body).to include("Test Subject")
+        expect(response.body).to include("This is a test message.")
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      it "再びお問い合わせフォームが含まれていること" do
+        post confirm_contacts_path, params: invalid_params
+        expect(response).to have_http_status(200)
+        expect(flash[:alert]).to include("を入力してください")
+        expect(response.body).to include("お問い合わせ")
+      end
+    end
+  end
+
+  describe "POST /contacts/back" do
+    it "入力画面に戻ると、入力内容が保持された状態でフォームが含まれていること" do
+      post confirm_contacts_path, params: valid_params
+      post back_contacts_path, params: valid_params
+      expect(response).to have_http_status(200)
+      expect(response.body).to include("Test User")
+      expect(response.body).to include("test@example.com")
+      expect(response.body).to include("Test Subject")
+      expect(response.body).to include("This is a test message.")
+    end
+  end
+
+  describe "POST /contacts" do
+    context "有効なパラメータの場合" do
+      it "お問い合わせが送信され、トップページにリダイレクトされること" do
+        expect { post contacts_path, params: valid_params }.to change(Contact, :count).by(1)
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to include(ENV['GOOGLE_MAIL_ADDRESS'])
+        expect(mail.subject).to include("【お問い合わせ】")
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to include("お問い合わせが完了しました。")
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      it "お問い合わせフォームが再び含まれていること" do
+        expect { post contacts_path, params: invalid_params }.not_to change(Contact, :count)
+        expect(response.body).to include("お問い合わせ")
+      end
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe "Home", type: :request do
       expect(response.body).not_to include(recipes[0].title)
     end
 
+    it "お問い合わせへのリンクが含まれていること" do
+      expect(response.body).to include("お問い合わせは")
+      expect(response.body).to include("こちら")
+    end
+
     context "管理者ユーザーの場合" do
       let(:admin_user) { create(:user, admin: true) }
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Users", type: :request do
         it "ユーザーが作成されない" do
           expect { post user_registration_path, params: { user: { name: "", email: "invalid", password: "short" } } }.
             not_to change(User, :count)
-          expect(response.body).to include("ユーザーネームを入力してください", "Eメールは不正な値です", "パスワードは6文字以上で入力してください")
+          expect(response.body).to include("ユーザーネームを入力してください", "メールアドレスは不正な値です", "パスワードは6文字以上で入力してください")
         end
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe "Users", type: :request do
       context "無効なパラメータの場合" do
         it "ログインに失敗する" do
           post user_session_path, params: { user: { email: user.email, password: "wrong_password" } }
-          expect(response.body).to include("Eメールまたはパスワードが違います")
+          expect(response.body).to include("メールアドレスまたはパスワードが違います")
         end
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe "Users", type: :request do
         it "アカウント情報更新に失敗すること" do
           invalid_image = Rack::Test::UploadedFile.new(image_file_path("invalid_image.txt"), "text/plain")
           patch user_registration_path, params: { user: { name: "", email: "invalid", avatar: invalid_image } }
-          expect(response.body).to include("ユーザーネームを入力してください", "Eメールは不正な値です", "アイコン画像は許可されていない拡張子です")
+          expect(response.body).to include("ユーザーネームを入力してください", "メールアドレスは不正な値です", "アイコン画像は許可されていない拡張子です")
         end
       end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Users", type: :system do
       expect(current_path).to eq user_registration_path
       expect(page).to have_content("エラーが発生したため ユーザー は保存されませんでした。")
       expect(page).to have_content("ユーザーネームを入力してください")
-      expect(page).to have_content("Eメールは不正な値です")
+      expect(page).to have_content("メールアドレスは不正な値です")
       expect(page).to have_content("パスワードは6文字以上で入力してください")
       expect(page).to have_content("パスワード（確認用）とパスワードの入力が一致しません")
     end
@@ -68,7 +68,7 @@ RSpec.describe "Users", type: :system do
       click_button "ログイン"
 
       expect(current_path).to eq new_user_session_path
-      expect(page).to have_content("Eメールまたはパスワードが違います")
+      expect(page).to have_content("メールアドレスまたはパスワードが違います")
     end
 
     it "ブラウザタブのタイトルが正しく表示されること" do
@@ -171,7 +171,7 @@ RSpec.describe "Users", type: :system do
       click_button "更新する"
 
       expect(page).to have_content("ユーザーネームを入力してください")
-      expect(page).to have_content("Eメールは不正な値です")
+      expect(page).to have_content("メールアドレスは不正な値です")
       expect(page).to have_content("許可されていない拡張子です")
     end
 


### PR DESCRIPTION
実装内容

ユーザーがお問い合わせ内容を入力・確認・送信できるフォームを実装しました。

1. contactコントローラを作成し以下のアクションを追加
- new, create: : お問い合わせ内容作成
- confirm: お問い合わせ内容確認
- back: 確認後修正する場合の修正
2. contactモデルの作成
3. contact_mailerで指定のメールアドレスに送信、送信内容の修正を実装
4. フッターにお問い合わせフォームへのリンクを設置