### PR TITLE
UIとrspecの修正

### DIFF
--- a/app/javascript/packs/recipe_form.js
+++ b/app/javascript/packs/recipe_form.js
@@ -9,10 +9,10 @@ $(document).on('turbolinks:load', function() {
     <div class="ingredient-group">
       <div class="row g-3 mb-3 align-items-end">
         <div class="col-6">
-          <input type="text" name="recipe[ingredients_attributes][${index}][name]" class="form-control form-pink" placeholder="例: トマト">
+          <input type="text" name="recipe[ingredients_attributes][${index}][name]" class="form-control form-pink" placeholder="例: トマト(20文字以内)">
         </div>
         <div class="col-5">
-          <input type="text" name="recipe[ingredients_attributes][${index}][quantity]" class="form-control form-pink" placeholder="例: 100g">
+          <input type="text" name="recipe[ingredients_attributes][${index}][quantity]" class="form-control form-pink" placeholder="例: 100g(20文字以内)">
         </div>
         <div class="col-1">
           <input type="hidden" name="recipe[ingredients_attributes][${index}][_destroy]" value="false" id="destroy-ingredient-${index}">
@@ -31,7 +31,7 @@ $(document).on('turbolinks:load', function() {
         <div class="row g-3 mb-3 align-items-end">
           <div class="col-11">
             <label class="form-label">手順 ${index + 1}</label>
-            <textarea name="recipe[instructions_attributes][${index}][description]" class="form-control form-pink" rows="2" placeholder="例: フライパンにオリーブオイルを熱し、トマトを炒める"></textarea>
+            <textarea name="recipe[instructions_attributes][${index}][description]" class="form-control form-pink" rows="2" placeholder="例: フライパンにオリーブオイルを熱し、トマトを炒める(100文字以内)"></textarea>
           </div>
           <div class="col-1">
             <input type="hidden" name="recipe[instructions_attributes][${index}][_destroy]" value="false" id="destroy-instruction-${index}">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -30,7 +30,7 @@
                 <div class="col-12">
                   <div class="form-floating mb-3">
                     <%= f.text_area :bio, class: "form-control", style: "height: 100px;" %>
-                    <%= f.label :bio, "自己紹介" %>
+                    <%= f.label :bio, "自己紹介(200文字以内)" %>
                   </div>
                 </div>
                 <div class="col-12">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,7 +79,8 @@
       <%= link_to '管理者ログイン', rails_admin_path %>
     <% end %>
     <div class="d-flex">
-     <p>お問い合わせは<span><%= link_to "こちら", new_contact_path, class:"text-decoration-none" %></span></p>
+     <p class="mb-2">お問い合わせは<span><%= link_to "こちら", new_contact_path, class:"text-decoration-none" %></span></p>
     </div>
+    <p>© 2025 Seigo Kato</p>
   </footer>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
                   <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
                 </li>
                 <li class="nav-item text-center">
-                  <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
+                  <%= link_to "新規登録", new_user_registration_path, class: "nav-link me-3" %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,7 +6,7 @@
         <div class="card mb-4">
           <div class="card-body text-center position-relative">
             <% if @user == current_user %>
-              <%= link_to "編集", edit_user_registration_path, class: "position-absolute edit-profile-position" %>
+              <%= link_to "編集", edit_user_registration_path, class: "position-absolute edit-profile-position text-decoration-none" %>
             <% end %>
             <%= image_tag(@user.avatar.url, alt: "アバター画像", class: "img-fluid rounded-circle img-fluid mb-3") %>
             <div class="row mb-2">

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -9,12 +9,12 @@
             <%= render "shared/error_messages", object: @recipe %>
             <div class="mb-3 pt-2">
               <%= form.label :title, "レシピタイトル", class: "form-label" %>
-              <%= form.text_field :title, class: "form-control", placeholder: "例: 〇〇のトマトパスタ" %>
+              <%= form.text_field :title, class: "form-control", placeholder: "例: 〇〇のトマトパスタ(30文字以内)" %>
             </div>
             <div class="row">
               <div class="mb-3 col-7">
                 <%= form.label :work_name, "作品名", class: "form-label" %>
-                <%= form.text_field :work_name, class: "form-control", placeholder: "例: ワンピース" %>
+                <%= form.text_field :work_name, class: "form-control", placeholder: "例: ワンピース(30文字以内)" %>
               </div>
               <div class="mb-3 col-5">
                 <%= form.label :category_id, "カテゴリー", class:"form-label d-block" %>
@@ -37,7 +37,7 @@
 
             <div class="mb-3">
               <%= form.label :tip, "ポイント・コツ", class: "form-label" %>
-              <%= form.text_area :tip, class: "form-control", rows: 3, placeholder: "例: トマトをしっかり炒めることで、酸味を飛ばし美味しくなります。" %>
+              <%= form.text_area :tip, class: "form-control", rows: 3, placeholder: "例: トマトをしっかり炒めることで、酸味を飛ばし美味しくなります。(100文字以内)" %>
             </div>
 
             <h2 class="mt-5 mb-3">材料</h2>
@@ -56,10 +56,10 @@
                     <%= form.hidden_field "ingredients_attributes[#{index}][id]", value: ingredient.id %>
                     <div class="row g-3 mb-3 align-items-end">
                       <div class="col-6">
-                        <%= form.text_field "ingredients_attributes[#{index}][name]", value: ingredient.name, class: "form-control", placeholder: "例: トマト" %>
+                        <%= form.text_field "ingredients_attributes[#{index}][name]", value: ingredient.name, class: "form-control", placeholder: "例: トマト(20文字以内)" %>
                       </div>
                       <div class="col-5">
-                        <%= form.text_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity, class: "form-control", placeholder: "例: 100g" %>
+                        <%= form.text_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity, class: "form-control", placeholder: "例: 100g(20文字以内)" %>
                       </div>
                       <div class="col-1">
                         <%= form.hidden_field "ingredients_attributes[#{index}][_destroy]",
@@ -84,7 +84,7 @@
                     <div class="row g-3 mb-3 align-items-end">
                       <div class="col-11">
                         <%= form.label :description, "手順 #{index + 1}", class: "form-label" %>
-                        <%= form.text_area "instructions_attributes[#{index}][description]", value: instruction.description, class: "form-control", rows: 2, placeholder: "例: フライパンにオリーブオイルを熱し、トマトを炒める" %>
+                        <%= form.text_area "instructions_attributes[#{index}][description]", value: instruction.description, class: "form-control", rows: 2, placeholder: "例: フライパンにオリーブオイルを熱し、トマトを炒める(100文字以内)" %>
                       </div>
                       <div class="col-1">
                       <%= form.hidden_field "instructions_attributes[#{index}][_destroy]",

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -36,8 +36,8 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :tip, "ポイント・コツ", class: "form-label" %>
-              <%= form.text_area :tip, class: "form-control", rows: 3, placeholder: "例: トマトをしっかり炒めることで、酸味を飛ばし美味しくなります。(100文字以内)" %>
+              <%= form.label :tip, "ポイント・コツ(200文字以内)", class: "form-label" %>
+              <%= form.text_area :tip, class: "form-control", rows: 3, placeholder: "例: トマトをしっかり炒めることで、酸味を飛ばし美味しくなります。" %>
             </div>
 
             <h2 class="mt-5 mb-3">材料</h2>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -9,12 +9,12 @@
             <%= render "shared/error_messages", object: @recipe %>
             <div class="mb-3 pt-2">
               <%= form.label :title, "レシピタイトル", class: "form-label" %>
-              <%= form.text_field :title, class: "form-control", placeholder: "例: 〇〇のトマトパスタ" %>
+              <%= form.text_field :title, class: "form-control", placeholder: "例: 〇〇のトマトパスタ(30文字以内)" %>
             </div>
             <div class="row">
               <div class="mb-3 col-7">
                 <%= form.label :work_name, "作品名", class: "form-label" %>
-                <%= form.text_field :work_name, class: "form-control", placeholder: "例: ワンピース" %>
+                <%= form.text_field :work_name, class: "form-control", placeholder: "例: ワンピース(30文字以内)" %>
               </div>
               <div class="mb-3 col-5">
                 <%= form.label :category_id, "カテゴリー", class:"form-label d-block" %>
@@ -52,10 +52,10 @@
                   <div class="ingredient-group">
                     <div class="row g-3 mb-3 align-items-end">
                       <div class="col-6">
-                        <%= form.text_field "ingredients_attributes[#{index}][name]", value: ingredient.name, class: "form-control", placeholder: "例: トマト" %>
+                        <%= form.text_field "ingredients_attributes[#{index}][name]", value: ingredient.name, class: "form-control", placeholder: "例: トマト(20文字以内)" %>
                       </div>
                       <div class="col-5">
-                        <%= form.text_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity, class: "form-control", placeholder: "例: 100g" %>
+                        <%= form.text_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity, class: "form-control", placeholder: "例: 100g(20文字以内)" %>
                       </div>
                       <div class="col-1">
                         <button type="button", class="btn-close mb-2 remove-ingredient", aria-label="Close"></button>
@@ -75,7 +75,7 @@
                     <div class="row g-3 mb-3 align-items-end">
                       <div class="col-11">
                         <%= form.label :description, "手順 #{index + 1}", class: "form-label" %>
-                        <%= form.text_area "instructions_attributes[#{index}][description]", value: instruction.description, class: "form-control", rows: 2, placeholder: "例: フライパンにオリーブオイルを熱し、トマトを炒める" %>
+                        <%= form.text_area "instructions_attributes[#{index}][description]", value: instruction.description, class: "form-control", rows: 2, placeholder: "例: フライパンにオリーブオイルを熱し、トマトを炒める(100文字以内)" %>
                       </div>
                       <div class="col-1">
                         <button type="button" class="btn-close mb-3 remove-instruction" aria-label="Close"></button>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -33,7 +33,7 @@
 
 
             <div class="mb-3">
-              <%= form.label :tip, "ポイント・コツ", class: "form-label" %>
+              <%= form.label :tip, "ポイント・コツ(200文字以内)", class: "form-label" %>
               <%= form.text_area :tip, class: "form-control", rows: 3, placeholder: "例: トマトをしっかり炒めることで、酸味を飛ばし美味しくなります。" %>
             </div>
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -104,7 +104,7 @@
                 <%= form_with(model: [@recipe, @comment], local: true) do |f| %>
                   <div class="mb-3">
                     <%= f.label :content, "コメント", class: "mb-1" %>
-                    <%= f.text_area :content, rows: 3, class: "form-control" %>
+                    <%= f.text_area :content, rows: 3, placeholder: "(200文字以内)", class: "form-control" %>
                   </div>
                   <div class="d-flex justify-content-end">
                     <%= f.submit "投稿する", class: "btn" %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
   config.hosts += ["web", "www.example.com"]
-
+  config.action_mailer.default_url_options = { host: "www.example.com" }
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,3 @@
-# ユーザー作成
 User.create!(
   [
     { email: "user1@example.com", password: "password", name: "User One", bio: "I love cooking!", avatar: "default.png" }
@@ -63,6 +62,27 @@ recipe = Recipe.create!(
     { step: 2, description: "つゆが沸いたら、麺を温める。" },
     { step: 3, description: "どんぶりに麺を移し、つゆ、山芋を山芋をかける。" },
     { step: 4, description: "卵黄、ねぎ、刻み海苔をかけ、わさびをお好みで添えたら完成です。" }
+  ]
+)
+
+recipe = Recipe.create!(
+  title: "ラピュタパン",
+  work_name: "天空の城ラピュタ",
+  user: User.first,
+  category: Category.find_by(name: "アニメ"),
+  recipe_image: File.open(Rails.root.join("app/assets/images/rapyuta_bread.jpg")),
+  tip: "Lサイズの卵だとこぼれることがあるので、大きすぎない卵を使うことをお勧めします。",
+  ingredients_attributes: [
+    { name: "食パン", quantity: "1枚" },
+    { name: "卵", quantity: "1個" },
+    { name: "マヨネーズ", quantity: "適量" },
+    { name: "塩", quantity: "適量" },
+    { name: "胡椒", quantity: "適量" }
+  ],
+  instructions_attributes: [
+    { step: 1, description: "食パンふちを2段ほどマヨネーズで囲います。" },
+    { step: 2, description: "真ん中に卵を落とします。" },
+    { step: 3, description: "塩、胡椒を振り、アルミホイルに乗せてトースターで6〜8分焼きます" }
   ]
 )
 

--- a/spec/mailers/password_mailer_spec.rb
+++ b/spec/mailers/password_mailer_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Devise::Mailer, type: :mailer do
+  describe "#reset_instructions" do
+    let(:user) { create(:user) }
+    let(:reset_token) do
+      token = user.send_reset_password_instructions
+      user.reload
+      token
+    end
+    let(:mail) { Devise::Mailer.reset_password_instructions(user, reset_token) }
+
+    it "正しい送信元が設定されていること" do
+      expect(mail.from).to eq(["noreply@example.com"])
+    end
+
+    it "正しい送信先が設定されていること" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "正しい件名が設定されていること" do
+      expect(mail.subject).to include("パスワードの再設定")
+    end
+
+    it "メール本文にパスワードリセットのリンクが含まれていること" do
+      expect(mail.body.encoded).to include("パスワードの変更を受け付けました。以下のリンクから変更できます。")
+    end
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Comments", type: :request do
         end
 
         context "無効なパラメータの場合" do
-          it "コメント作成に失敗し、メッセージが表示されること" do
+          it "コメント作成に失敗し、リダイレクト先にフラッシュメッセージが含まれていること" do
             expect { post recipe_comments_path(recipe), params: { comment: invalid_attributes } }.not_to change(Comment, :count)
             expect(response).to redirect_to(recipe_path(recipe))
             follow_redirect!

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Home", type: :request do
       expect(response.body).to include("人気レシピ")
     end
 
-    it "人気レシピとして人気のも最も高い3つのみが表示されること" do
+    it "人気レシピとして人気のも最も高い3つのみが含まれていること" do
       html = Nokogiri::HTML(response.body)
       popular_section = html.at_css('.popular-recipes-area')
       popular_text = popular_section.text
@@ -43,7 +43,7 @@ RSpec.describe "Home", type: :request do
       expect(popular_text).not_to include(recipes[0].title)
     end
 
-    it "各カテゴリのレシピセクションが表示されていること" do
+    it "各カテゴリのレシピセクションが含まれていること" do
       get root_path
       categories.each do |category|
         expect(response.body).to include(category.name)


### PR DESCRIPTION
変更内容

1. 文字数制限が付いているフォームのラベル、プレイスホルダーに制限数を記述
2. プロフィールの編集ボタンのtext-decrationを排除
3. フッターにコピーライト表記を記述
4. パスワード変更時のrspecテストを追加
5. リクエストスペックのタイトルを修正